### PR TITLE
Improve image saving response format and update related services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       - ./nginx/conf:/etc/nginx/conf.d
       - ./nginx/logs:/var/log/nginx
       - images-data:/usr/share/nginx/images:ro
-
+    command: [
+      "sh", "-c",
+      "printf 'upstream profile_upstream {\n    server image-server-1:8080;\n    server image-server-2:8080;\n    server image-server-3:8080;\n}\n\nserver {\n    listen 80;\n    location / {\n        proxy_pass http://profile_upstream;\n        proxy_set_header Host $$host;\n        proxy_set_header X-Real-IP $$remote_addr;\n        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;\n        proxy_set_header X-Forwarded-Proto $$scheme;\n    }\n}\n' > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    ]
     depends_on:
       - image-server-1
       - image-server-2
@@ -26,33 +29,23 @@ services:
 
   # auth-server 인스턴스들을 개별 서비스로 정의 (Compose는 deploy.replicas를 적용하지 않으므로 이렇게 복수 서비스로 표현)
   image-server-1:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-1
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
     volumes:
       - images-data:/uploads
 
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-
   image-server-2:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-2
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
@@ -67,18 +60,22 @@ services:
       retries: 3
 
   image-server-3:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-3
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
     volumes:
       - images-data:/uploads
+
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
 
 

--- a/src/main/java/com/teambind/image_server/controller/ImageConfirmController.java
+++ b/src/main/java/com/teambind/image_server/controller/ImageConfirmController.java
@@ -19,8 +19,10 @@ public class ImageConfirmController {
 
     //TODO CONVERT EVENT Handling
     @PatchMapping("/{imageId}/confirm")
-    public void confirmImage(@PathVariable(name = "imageId") String imageId) throws Exception {
+    public void confirmImage(@PathVariable(name = "imageId") String imageId) {
         Image image = imageConfirmService.confirmImage(imageId);
         eventPublisher.imageChangeEvent(image);
     }
+
+
 }

--- a/src/main/java/com/teambind/image_server/controller/ImageSaveController.java
+++ b/src/main/java/com/teambind/image_server/controller/ImageSaveController.java
@@ -1,8 +1,6 @@
 package com.teambind.image_server.controller;
 
 
-import com.teambind.image_server.entity.Image;
-import com.teambind.image_server.exception.CustomException;
 import com.teambind.image_server.service.ImageSaveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -13,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,19 +21,15 @@ public class ImageSaveController {
     private final ImageSaveService imageSaveService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> saveImage(@RequestParam("file") MultipartFile file, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) throws CustomException {
-        Image image = imageSaveService.saveImage(file, referenceId, uploaderId, category);
-        return ResponseEntity.ok().body(image.getId());
+    public ResponseEntity<Map<String, String>> saveImage(@RequestParam("file") MultipartFile file, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) {
+        Map<String, String> image = imageSaveService.saveImage(file, referenceId, uploaderId, category);
+        return ResponseEntity.ok().body(image);
     }
 
     @PostMapping(path = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<List<String>> saveImages(@RequestParam("files") List<MultipartFile> files, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) throws CustomException {
-        List<Image> image = imageSaveService.saveImages(files, referenceId, uploaderId, category);
-        List<String> imageIds = new ArrayList<>();
-        for (Image img : image) {
-            imageIds.add(img.getId());
-        }
+    public ResponseEntity<Map<String, String>> saveImages(@RequestParam("files") List<MultipartFile> files, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) {
+        Map<String, String> image = imageSaveService.saveImages(files, referenceId, uploaderId, category);
 
-        return ResponseEntity.ok().body(imageIds);
+        return ResponseEntity.ok().body(image);
     }
 }

--- a/src/main/java/com/teambind/image_server/exception/CustomException.java
+++ b/src/main/java/com/teambind/image_server/exception/CustomException.java
@@ -2,7 +2,7 @@ package com.teambind.image_server.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class CustomException extends Exception {
+public class CustomException extends RuntimeException {
     private final ErrorCode errorcode;
 
     public CustomException(ErrorCode errorcode) {

--- a/src/main/java/com/teambind/image_server/service/ImageSaveService.java
+++ b/src/main/java/com/teambind/image_server/service/ImageSaveService.java
@@ -18,8 +18,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.teambind.image_server.ImageServerApplication.extensionMap;
@@ -35,7 +36,7 @@ public class ImageSaveService {
     private final LocalImageStorage imageStorage;
     private final ExtensionParser extensionParser;
 
-    public Image saveImage(MultipartFile file, String referenceId, String uploaderId, String category) throws CustomException {
+    public Map<String, String> saveImage(MultipartFile file, String referenceId, String uploaderId, String category) throws CustomException {
         if (!extensionValidator.isValid(file.getOriginalFilename())) {
             throw new CustomException(ErrorCode.FILE_EXTENSION_NOT_FOUND);
         }
@@ -45,7 +46,7 @@ public class ImageSaveService {
         return saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category);
     }
 
-    private Image saveImage(MultipartFile file, String referenceId, String fileName, String uploaderId, String category) throws CustomException {
+    private Map<String, String> saveImage(MultipartFile file, String referenceId, String fileName, String uploaderId, String category) throws CustomException {
         String uuid = UUID.randomUUID().toString(); // ImageId
         String datePath = LocalDateTime.now().toLocalDate().toString().replace("-", "/");
 
@@ -114,13 +115,13 @@ public class ImageSaveService {
 
         image.setStorageObject(storageObject);
         imageRepository.save(image);
-        return image;
+        return Map.of("id", fileName, "url", image.getImageUrl());
     }
 
-    public List<Image> saveImages(List<MultipartFile> files, String referenceId, String uploaderId, String category) throws CustomException {
-        List<Image> images = new ArrayList<>();
+    public Map<String, String> saveImages(List<MultipartFile> files, String referenceId, String uploaderId, String category) throws CustomException {
+        Map<String, String> images = new HashMap<>();
         for (MultipartFile file : files) {
-            images.add(saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category));
+            images.put(file.getOriginalFilename(), saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category).get("url"));
         }
         return images;
     }

--- a/src/test/java/com/teambind/image_server/service/ImageSaveServiceSpringBootTest.java
+++ b/src/test/java/com/teambind/image_server/service/ImageSaveServiceSpringBootTest.java
@@ -94,11 +94,19 @@ class ImageSaveServiceSpringBootTest {
         assertThat(profile).isNotNull();
 
         // when
-        Image saved = saveService.saveImage(file, "123", "user-100", "PROFILE");
+        java.util.Map<String, String> result = saveService.saveImage(file, "123", "user-100", "PROFILE");
 
-        // then: DB 적재
-        assertThat(saved.getId()).isNotBlank();
-        Image found = imageRepository.findById(saved.getId()).orElseThrow();
+        // then: 응답 포맷 검증
+        assertThat(result).containsKeys("id", "url");
+        assertThat(result.get("id")).isEqualTo("ok.png");
+        assertThat(result.get("url")).isNotBlank();
+
+        // and: DB 적재
+        // 반환값에 UUID가 포함되지 않으므로 URL로 역조회하여 검증한다
+        Image found = imageRepository.findAll().stream()
+                .filter(img -> result.get("url").equals(img.getImageUrl()))
+                .findFirst()
+                .orElseThrow();
         assertThat(found.getStorageObject()).isNotNull();
         assertThat(found.getStorageObject().getConvertedSize()).isNotNull();
         assertThat(found.getReferenceType().getCode()).isEqualTo("PROFILE");


### PR DESCRIPTION
### Overview

This pull request introduces enhancements and updates to the image saving functionality.

### Changes
- Changed the response format of image saving to a `Map` structure for better clarity and flexibility.
- Updated relevant services and controllers to align with the new response format.
- Added test cases for the updated `Map`-based response.
- Upgraded the image server version from 1.8 to 1.9 in `docker-compose.yml`.
- Added Nginx configuration and multi-instance load balancing support.
- Improved exceptions by converting `CustomException` to inherit from `RuntimeException`.
- Removed unnecessary `throws` clauses and implemented minor improvements in `ImageConfirmController`.

### Notes
- Database migration and load-balancing environment setup need to be verified before deployment.

No unresolved issues are mentioned at this time.