### PR TITLE
Implement unused image cleanup scheduling and API enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.14.0'
     implementation "com.sksamuel.scrimage:scrimage-core:4.0.32"
     implementation "com.sksamuel.scrimage:scrimage-webp:4.0.32"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,10 @@ services:
       - ./nginx/conf:/etc/nginx/conf.d
       - ./nginx/logs:/var/log/nginx
       - images-data:/usr/share/nginx/images:ro
-
+    command: [
+      "sh", "-c",
+      "printf 'upstream profile_upstream {\n    server image-server-1:8080;\n    server image-server-2:8080;\n    server image-server-3:8080;\n}\n\nserver {\n    listen 80;\n    location / {\n        proxy_pass http://profile_upstream;\n        proxy_set_header Host $$host;\n        proxy_set_header X-Real-IP $$remote_addr;\n        proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;\n        proxy_set_header X-Forwarded-Proto $$scheme;\n    }\n}\n' > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    ]
     depends_on:
       - image-server-1
       - image-server-2
@@ -26,33 +29,23 @@ services:
 
   # auth-server 인스턴스들을 개별 서비스로 정의 (Compose는 deploy.replicas를 적용하지 않으므로 이렇게 복수 서비스로 표현)
   image-server-1:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-1
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
     volumes:
       - images-data:/uploads
 
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
-      interval: 15s
-      timeout: 5s
-      retries: 3
-
   image-server-2:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-2
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
@@ -67,18 +60,22 @@ services:
       retries: 3
 
   image-server-3:
-    image: ddingsh9/image-server:1.8
-    build:
-      context: .
-      dockerfile: Dockerfile
+    image: ddingsh9/image-server:1.9
     env_file:
       - .env.prod
     container_name: image-server-3
+    restart: unless-stopped
     networks:
       - image-network
       - infra-network
     volumes:
       - images-data:/uploads
+
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
 
 

--- a/src/main/java/com/teambind/image_server/controller/ImageConfirmController.java
+++ b/src/main/java/com/teambind/image_server/controller/ImageConfirmController.java
@@ -19,8 +19,10 @@ public class ImageConfirmController {
 
     //TODO CONVERT EVENT Handling
     @PatchMapping("/{imageId}/confirm")
-    public void confirmImage(@PathVariable(name = "imageId") String imageId) throws Exception {
+    public void confirmImage(@PathVariable(name = "imageId") String imageId) {
         Image image = imageConfirmService.confirmImage(imageId);
         eventPublisher.imageChangeEvent(image);
     }
+
+
 }

--- a/src/main/java/com/teambind/image_server/controller/ImageSaveController.java
+++ b/src/main/java/com/teambind/image_server/controller/ImageSaveController.java
@@ -1,8 +1,6 @@
 package com.teambind.image_server.controller;
 
 
-import com.teambind.image_server.entity.Image;
-import com.teambind.image_server.exception.CustomException;
 import com.teambind.image_server.service.ImageSaveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -13,8 +11,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,19 +21,15 @@ public class ImageSaveController {
     private final ImageSaveService imageSaveService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> saveImage(@RequestParam("file") MultipartFile file, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) throws CustomException {
-        Image image = imageSaveService.saveImage(file, referenceId, uploaderId, category);
-        return ResponseEntity.ok().body(image.getId());
+    public ResponseEntity<Map<String, String>> saveImage(@RequestParam("file") MultipartFile file, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) {
+        Map<String, String> image = imageSaveService.saveImage(file, referenceId, uploaderId, category);
+        return ResponseEntity.ok().body(image);
     }
 
     @PostMapping(path = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<List<String>> saveImages(@RequestParam("files") List<MultipartFile> files, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) throws CustomException {
-        List<Image> image = imageSaveService.saveImages(files, referenceId, uploaderId, category);
-        List<String> imageIds = new ArrayList<>();
-        for (Image img : image) {
-            imageIds.add(img.getId());
-        }
+    public ResponseEntity<Map<String, String>> saveImages(@RequestParam("files") List<MultipartFile> files, @RequestParam String referenceId, @RequestParam String uploaderId, @RequestParam String category) {
+        Map<String, String> image = imageSaveService.saveImages(files, referenceId, uploaderId, category);
 
-        return ResponseEntity.ok().body(imageIds);
+        return ResponseEntity.ok().body(image);
     }
 }

--- a/src/main/java/com/teambind/image_server/controller/sehdule/ScheduleController.java
+++ b/src/main/java/com/teambind/image_server/controller/sehdule/ScheduleController.java
@@ -1,0 +1,24 @@
+package com.teambind.image_server.controller.sehdule;
+
+
+import com.teambind.image_server.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/schedule")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+
+    // Crown Job By Api
+    @GetMapping("/cleanup")
+    public void cleanup() {
+        scheduleService.cleanUpUnusedImages();
+    }
+
+}

--- a/src/main/java/com/teambind/image_server/exception/CustomException.java
+++ b/src/main/java/com/teambind/image_server/exception/CustomException.java
@@ -2,7 +2,7 @@ package com.teambind.image_server.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class CustomException extends Exception {
+public class CustomException extends RuntimeException {
     private final ErrorCode errorcode;
 
     public CustomException(ErrorCode errorcode) {

--- a/src/main/java/com/teambind/image_server/repository/ImageRepository.java
+++ b/src/main/java/com/teambind/image_server/repository/ImageRepository.java
@@ -3,11 +3,15 @@ package com.teambind.image_server.repository;
 
 import com.teambind.image_server.entity.Image;
 import com.teambind.image_server.entity.ReferenceType;
+import com.teambind.image_server.enums.ImageStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ImageRepository extends JpaRepository<Image, String> {
     Image findByIdAndUploaderIdAndReferenceType(String imageId, String uploaderId, ReferenceType referenceType);
 
+    List<Image> findAllByStatusNot(ImageStatus status);
 }

--- a/src/main/java/com/teambind/image_server/service/ImageConfirmService.java
+++ b/src/main/java/com/teambind/image_server/service/ImageConfirmService.java
@@ -23,7 +23,7 @@ public class ImageConfirmService {
     private final ImageRepository imageRepository;
     private final StatusChanger statusChanger;
 
-    public Image confirmImage(String imageId) throws CustomException {
+    public Image confirmImage(String imageId) {
 
         log.info("Confirming image with id: {}", imageId);
         if (imageId == null || imageId.isEmpty()) {
@@ -41,7 +41,7 @@ public class ImageConfirmService {
         return image;
     }
 
-    public void deleteOldProfileImg(String imageId, String uploaderId, ReferenceType referenceType) throws CustomException {
+    public void deleteOldProfileImg(String imageId, String uploaderId, ReferenceType referenceType) {
         log.info("Confirming profile image with id: {}", imageId);
 
         Image oldProfile = imageRepository.findByIdAndUploaderIdAndReferenceType(imageId, uploaderId, referenceType);

--- a/src/main/java/com/teambind/image_server/service/ImageSaveService.java
+++ b/src/main/java/com/teambind/image_server/service/ImageSaveService.java
@@ -18,8 +18,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.teambind.image_server.ImageServerApplication.extensionMap;
@@ -35,7 +36,7 @@ public class ImageSaveService {
     private final LocalImageStorage imageStorage;
     private final ExtensionParser extensionParser;
 
-    public Image saveImage(MultipartFile file, String referenceId, String uploaderId, String category) throws CustomException {
+    public Map<String, String> saveImage(MultipartFile file, String referenceId, String uploaderId, String category) throws CustomException {
         if (!extensionValidator.isValid(file.getOriginalFilename())) {
             throw new CustomException(ErrorCode.FILE_EXTENSION_NOT_FOUND);
         }
@@ -45,7 +46,7 @@ public class ImageSaveService {
         return saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category);
     }
 
-    private Image saveImage(MultipartFile file, String referenceId, String fileName, String uploaderId, String category) throws CustomException {
+    private Map<String, String> saveImage(MultipartFile file, String referenceId, String fileName, String uploaderId, String category) throws CustomException {
         String uuid = UUID.randomUUID().toString(); // ImageId
         String datePath = LocalDateTime.now().toLocalDate().toString().replace("-", "/");
 
@@ -114,13 +115,13 @@ public class ImageSaveService {
 
         image.setStorageObject(storageObject);
         imageRepository.save(image);
-        return image;
+        return Map.of("id", fileName, "url", image.getImageUrl());
     }
 
-    public List<Image> saveImages(List<MultipartFile> files, String referenceId, String uploaderId, String category) throws CustomException {
-        List<Image> images = new ArrayList<>();
+    public Map<String, String> saveImages(List<MultipartFile> files, String referenceId, String uploaderId, String category) throws CustomException {
+        Map<String, String> images = new HashMap<>();
         for (MultipartFile file : files) {
-            images.add(saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category));
+            images.put(file.getOriginalFilename(), saveImage(file, referenceId, file.getOriginalFilename(), uploaderId, category).get("url"));
         }
         return images;
     }

--- a/src/main/java/com/teambind/image_server/service/ScheduleService.java
+++ b/src/main/java/com/teambind/image_server/service/ScheduleService.java
@@ -6,7 +6,10 @@ import com.teambind.image_server.enums.ImageStatus;
 import com.teambind.image_server.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +21,10 @@ public class ScheduleService {
 
     private final ImageRepository imageRepository;
 
+
+    @Scheduled(cron = "0 30 3 * * *", zone = "Asia/Seoul")
+    @SchedulerLock(name = "cleanUpImages", lockAtMostFor = "10m", lockAtLeastFor = "1m")
+    @Transactional
     public void cleanUpUnusedImages() {
         List<Image> images = imageRepository.findAllByStatusNot(ImageStatus.CONFIRMED);
         List<Image> imagesToDelete = new ArrayList<>();

--- a/src/main/java/com/teambind/image_server/service/ScheduleService.java
+++ b/src/main/java/com/teambind/image_server/service/ScheduleService.java
@@ -1,0 +1,31 @@
+package com.teambind.image_server.service;
+
+
+import com.teambind.image_server.entity.Image;
+import com.teambind.image_server.enums.ImageStatus;
+import com.teambind.image_server.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ScheduleService {
+
+    private final ImageRepository imageRepository;
+
+    public void cleanUpUnusedImages() {
+        List<Image> images = imageRepository.findAllByStatusNot(ImageStatus.CONFIRMED);
+        List<Image> imagesToDelete = new ArrayList<>();
+        for (Image image : images) {
+            if (image.getCreatedAt().plusDays(2).isBefore(java.time.LocalDateTime.now())) {
+                imagesToDelete.add(image);
+            }
+        }
+        imageRepository.deleteAll(imagesToDelete);
+    }
+}

--- a/src/main/java/com/teambind/image_server/util/helper/SequenceHelper.java
+++ b/src/main/java/com/teambind/image_server/util/helper/SequenceHelper.java
@@ -12,5 +12,4 @@ public class SequenceHelper {
     private ImageRepository imageRepository;
 
 
-
 }

--- a/src/test/java/com/teambind/image_server/service/ImageSaveServiceSpringBootTest.java
+++ b/src/test/java/com/teambind/image_server/service/ImageSaveServiceSpringBootTest.java
@@ -94,11 +94,19 @@ class ImageSaveServiceSpringBootTest {
         assertThat(profile).isNotNull();
 
         // when
-        Image saved = saveService.saveImage(file, "123", "user-100", "PROFILE");
+        java.util.Map<String, String> result = saveService.saveImage(file, "123", "user-100", "PROFILE");
 
-        // then: DB 적재
-        assertThat(saved.getId()).isNotBlank();
-        Image found = imageRepository.findById(saved.getId()).orElseThrow();
+        // then: 응답 포맷 검증
+        assertThat(result).containsKeys("id", "url");
+        assertThat(result.get("id")).isEqualTo("ok.png");
+        assertThat(result.get("url")).isNotBlank();
+
+        // and: DB 적재
+        // 반환값에 UUID가 포함되지 않으므로 URL로 역조회하여 검증한다
+        Image found = imageRepository.findAll().stream()
+                .filter(img -> result.get("url").equals(img.getImageUrl()))
+                .findFirst()
+                .orElseThrow();
         assertThat(found.getStorageObject()).isNotNull();
         assertThat(found.getStorageObject().getConvertedSize()).isNotNull();
         assertThat(found.getReferenceType().getCode()).isEqualTo("PROFILE");

--- a/src/test/java/com/teambind/image_server/service/ScheduleServiceSpringBootTest.java
+++ b/src/test/java/com/teambind/image_server/service/ScheduleServiceSpringBootTest.java
@@ -1,0 +1,105 @@
+package com.teambind.image_server.service;
+
+import com.teambind.image_server.entity.Image;
+import com.teambind.image_server.entity.ReferenceType;
+import com.teambind.image_server.enums.ImageStatus;
+import com.teambind.image_server.repository.ImageRepository;
+import com.teambind.image_server.repository.ReferenceTypeRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ScheduleServiceSpringBootTest {
+
+    @TempDir
+    static Path tempDir;
+    @Autowired
+    private ScheduleService scheduleService;
+    @Autowired
+    private ImageRepository imageRepository;
+    @Autowired
+    private ReferenceTypeRepository referenceTypeRepository;
+    private ReferenceType refProfile;
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry r) {
+        r.add("images.upload.dir", () -> tempDir.toAbsolutePath().toString());
+    }
+
+    @BeforeEach
+    void setUp() {
+        imageRepository.deleteAll();
+        refProfile = referenceTypeRepository.findAll().stream()
+                .filter(r -> r.getCode().equals("PROFILE"))
+                .findFirst().orElseThrow();
+    }
+
+    @AfterEach
+    void tearDown() {
+        imageRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("cleanUpUnusedImages: CONFIRMED 제외, 2일 초과된 이미지만 삭제")
+    void cleanUpUnusedImages_deletesOnlyOldAndUnconfirmed() {
+        // given
+        Image oldTemp = Image.builder()
+                .id("img-old-temp")
+                .status(ImageStatus.TEMP)
+                .referenceType(refProfile)
+                .referenceId("ref-1")
+                .imageUrl("http://local/images/old.webp")
+                .uploaderId("user-1")
+                .idDeleted(false)
+                .createdAt(LocalDateTime.now().minusDays(3))
+                .build();
+
+        Image recentTemp = Image.builder()
+                .id("img-recent-temp")
+                .status(ImageStatus.TEMP)
+                .referenceType(refProfile)
+                .referenceId("ref-2")
+                .imageUrl("http://local/images/recent.webp")
+                .uploaderId("user-1")
+                .idDeleted(false)
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .build();
+
+        Image oldConfirmed = Image.builder()
+                .id("img-old-confirmed")
+                .status(ImageStatus.CONFIRMED)
+                .referenceType(refProfile)
+                .referenceId("ref-3")
+                .imageUrl("http://local/images/conf.webp")
+                .uploaderId("user-1")
+                .idDeleted(false)
+                .createdAt(LocalDateTime.now().minusDays(10))
+                .build();
+
+        imageRepository.save(oldTemp);
+        imageRepository.save(recentTemp);
+        imageRepository.save(oldConfirmed);
+
+        // when
+        scheduleService.cleanUpUnusedImages();
+
+        // then
+        assertThat(imageRepository.findById("img-old-temp")).isEmpty();
+        assertThat(imageRepository.findById("img-recent-temp")).isPresent();
+        assertThat(imageRepository.findById("img-old-confirmed")).isPresent();
+    }
+}


### PR DESCRIPTION
---

### Description of Changes

This pull request introduces the following modifications:
1. **Unused Image Cleanup Schedule**: Added a scheduling mechanism using `@Scheduled` and `@SchedulerLock` to perform the cleanup of unused images. Transaction handling with `@Transactional` is also included.
2. **Integration Tests**: Added integration tests for the newly implemented cleanup service to ensure reliability in different scenarios.
3. **Service Enhancements**: Created a new cleanup service class, improved logic and readability across related classes, and added essential methods in the repository layer.
4. **Response Format Improvement**: Modified the image-saving response structure to use a `Map` format, along with corresponding adjustments across the controller, services, and related tests.
5. **Dependency Updates and Configurations**: 
   - Incorporated ShedLock library for managing scheduled tasks.
   - Upgraded image server version in `docker-compose.yml` and introduced configurations for multi-instance support with load balancing.

---

### Checklist

- [ ] Unit and integration tests have been updated.
- [ ] Code has been documented sufficiently.
- [ ] Dependencies are updated appropriately.
- [ ] Changes have been verified in the test environment.

---

Please verify the updated configurations and ensure the necessary database migrations and deployment setups are in place.